### PR TITLE
[DOP-3470]: Add correct favicon

### DIFF
--- a/cli/template.hbs
+++ b/cli/template.hbs
@@ -14,6 +14,7 @@
   </style>
   {{{redocHead}}}
   {{#unless disableGoogleFont}}<link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">{{/unless}}
+  <link href="https://www.mongodb.com/docs/assets/favicon.ico" rel="icon">
 </head>
 
 <body>


### PR DESCRIPTION
### Stories/Links:
[DOP-3470](https://jira.mongodb.org/browse/DOP-3470)

### Notes:
Added link tag to put the correct favicon. Not sure if there is a easy way to test.