### PR TITLE
DOP-3460: Introduce release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git config user.name 'github-actions[bot]'
-          git add -fn bundles/ typings/
-          git commit -m 'Add build artifacts'
+          git add -f bundles/ typings/
+          git commit --no-verify -m 'Add build artifacts'
           git tag ${{ steps.split.outputs._1 }}
           git push --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ jobs:
   release-redoc:
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.event.head_commit.message, '[RELEASE] - v') }}
+    env:
+      NPM_BASE_64_AUTH: ${{ secrets.NPM_BASE_64_AUTH }}
+      NPM_EMAIL: ${{ secrets.NPM_EMAIL }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git config user.name 'github-actions[bot]'
-          git add -f bundles/ typings/
+          git add -fn bundles/ typings/
           git commit -m 'Add build artifacts'
           git tag ${{ steps.split.outputs._1 }}
           git push --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,3 +41,32 @@ jobs:
           git commit --no-verify -m 'Add build artifacts'
           git tag ${{ steps.split.outputs._1 }}
           git push --tags
+  release-redoc-cli:
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.event.head_commit.message, '[RELEASE] - @dop/redoc-cli') }}
+    env:
+      NPM_BASE_64_AUTH: ${{ secrets.NPM_BASE_64_AUTH }}
+      NPM_EMAIL: ${{ secrets.NPM_EMAIL }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - name: Install dependencies
+        run: npm ci && npm ci --prefix cli
+      - name: Create bundles
+        run: npm run bundle
+      - name: Run unit tests
+        run: npm run test
+      - name: Run e2e tests
+        run: npm run e2e
+      - name: Split commit message
+        uses: jungwinter/split@v2
+        id: split
+        with:
+          msg: ${{ github.event.head_commit.message }}
+          separator: ' - '
+      - name: Push build artifacts and create tag
+        run: |
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git config user.name 'github-actions[bot]'
+          git tag ${{ steps.split.outputs._1 }}
+          git push --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - main
-      # TODO-3460: Delete this after testing
-      - DOP-3460
     paths:
       - 'package.json'
       - 'cli/package.json'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
       - name: Install dependencies
-        run: npm ci && npm ci --prefix=./cli
+        run: npm ci && npm ci --prefix cli
       - name: Create bundles
         run: npm run bundle
       - name: Run unit tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+on:
+  push:
+    branches:
+      - main
+      # TODO-3460: Delete this after testing
+      - DOP-3460
+    paths:
+      - 'package.json'
+jobs:
+  release-redoc:
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.event.head_commit.message, '[RELEASE] - v') }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - name: Install dependencies
+        run: npm ci && npm ci --prefix=./cli
+      - name: Create bundles
+        run: npm run bundle
+      - name: Run unit tests
+        run: npm run test
+      - name: Run e2e tests
+        run: npm run e2e
+      - name: Split commit message
+        uses: jungwinter/split@v2
+        id: split
+        with:
+          msg: ${{ github.event.head_commit.message }}
+          separator: ' - '
+      - name: Push build artifacts and create tag
+        # Use build artifacts in current branch, but only push it to new tag.
+        # Build artifacts are needed by redoc-cli since the dependency is pulled from a GitHub branch/tag.
+        run: |
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git config user.name 'github-actions[bot]'
+          git add -f bundles/ typings/
+          git commit -m 'Add build artifacts'
+          git tag ${{ steps.split.outputs._1 }}
+          git push --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
       - DOP-3460
     paths:
       - 'package.json'
+      - 'cli/package.json'
 jobs:
   release-redoc:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn.lock
 .idea
 .vscode
 .eslintcache
+
+# Test output from redoc-cli
+redoc-*.html

--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,4 @@ registry=https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/
 _auth=${NPM_BASE_64_AUTH}
 _email=${NPM_EMAIL}
 _always-auth=true
+git-tag-version=false

--- a/README.md
+++ b/README.md
@@ -40,6 +40,37 @@ With `node` installed, run by doing the following:
 node <path/to/redoc/cli/index.js> build <path/to/spec/file/or/url> --options=<path/to/options.json> --output=<path/to/custom/output/file/name.html>
 ```
 
+### Releasing
+
+The Redoc React component and the Redoc CLI have 2 separate release processes. Because the Redoc CLI pulls its version of Redoc from GitHub, build artifacts are included in the version tag being installed.
+
+See the sections below for release steps for each component. A release commit will be pushed to the `main` branch of `mongodb-forks/redoc` after following the steps, which will trigger a GitHub workflow. The workflow is responsible for testing, building artifacts (for the Redoc component, if applicable), and creating a tag.
+
+:warning: Note: Ensure that your local clone of the `mongodb-forks/redoc` repo is clean and up-to-date with the `main` branch. Please check your remotes to ensure that the `upstream` remote is set to the `mongodb-forks/redoc` repo. Example:
+
+```
+$ git remote -v
+upstream	https://github.com/mongodb-forks/redoc.git (fetch)
+upstream	https://github.com/mongodb-forks/redoc.git (push)
+```
+
+#### Redoc
+
+Releasing the Redoc React component can be done by:
+
+1) Go to your local clone of the `mongodb-forks/redoc` repo and ensure you are on the latest iteration of the `main` branch.
+2) Run `npm version [major | minor | patch | prerelease --preid=rc]`.
+
+#### Redoc CLI
+
+Releasing the Redoc CLI can be done by:
+
+1) Go to your local clone of the `mongodb-forks/redoc` repo and ensure you are on the latest iteration of the `main` branch.
+2) Go to the `cli/` directory.
+3) Run `npm install https://github.com/mongodb-forks/redoc.git#{VERSION_TAG}` to update the version of Redoc that the CLI uses.
+   - Example: `npm install https://github.com/mongodb-forks/redoc.git#v1.0.0`. You should see the version set in the CLI's `package.json`.
+4) Run `npm version [major | minor | patch | prerelease --preid=rc]`.
+
 ## About Redoc
 
 Redoc is an open-source tool for generating documentation from OpenAPI (fka Swagger) definitions.

--- a/cli/npm-shrinkwrap.json
+++ b/cli/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "redoc-cli",
-  "version": "0.0.1-test-rc.0",
+  "version": "0.0.1-test-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "redoc-cli",
-      "version": "0.0.1-test-rc.0",
+      "version": "0.0.1-test-rc.1",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.1",

--- a/cli/npm-shrinkwrap.json
+++ b/cli/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "redoc-cli",
-  "version": "0.13.20",
+  "version": "0.0.1-test-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "redoc-cli",
-      "version": "0.13.20",
+      "version": "0.0.1-test-rc.0",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dop/redoc-cli",
-  "version": "0.0.0",
+  "version": "0.0.1-test-rc.0",
   "description": "ReDoc's Command Line Interface",
   "main": "index.js",
   "bin": "index.js",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dop/redoc-cli",
-  "version": "0.0.1-test-rc.1",
+  "version": "0.0.0",
   "description": "ReDoc's Command Line Interface",
   "main": "index.js",
   "bin": "index.js",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,14 +1,17 @@
 {
-  "name": "redoc-cli",
-  "version": "0.13.20",
+  "name": "@dop/redoc-cli",
+  "version": "0.0.0",
   "description": "ReDoc's Command Line Interface",
   "main": "index.js",
   "bin": "index.js",
-  "repository": "https://github.com/Redocly/redoc",
-  "author": "Roman Hotsiy <gotsijroman@gmail.com>",
+  "repository": "https://github.com/mongodb-forks/redoc",
   "license": "MIT",
   "engines": {
     "node": ">=12.0.0"
+  },
+  "scripts": {
+    "version": "git add -u . && git commit -m \"[RELEASE] - @dop/redoc-cli@$npm_package_version\"",
+    "postversion": "git push upstream DOP-3460"
   },
   "dependencies": {
     "chokidar": "^3.5.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "version": "git add -u . && git commit -m \"[RELEASE] - @dop/redoc-cli@$npm_package_version\"",
-    "postversion": "git push upstream DOP-3460"
+    "postversion": "git push upstream main"
   },
   "dependencies": {
     "chokidar": "^3.5.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dop/redoc-cli",
-  "version": "0.0.1-test-rc.0",
+  "version": "0.0.1-test-rc.1",
   "description": "ReDoc's Command Line Interface",
   "main": "index.js",
   "bin": "index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dop/redoc",
-  "version": "0.0.1-rc.0",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dop/redoc",
-      "version": "0.0.1-rc.0",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "@emotion/css": "^11.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "redoc",
-  "version": "2.0.0",
+  "name": "@dop/redoc",
+  "version": "0.0.1-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "redoc",
-      "version": "2.0.0",
+      "name": "@dop/redoc",
+      "version": "0.0.1-rc.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/css": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dop/redoc",
-  "version": "0.0.1-test-rc.3",
+  "version": "0.0.1",
   "description": "ReDoc",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dop/redoc",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "ReDoc",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dop/redoc",
-  "version": "0.0.1-rc.0",
+  "version": "0.0.1-test-rc.0",
   "description": "ReDoc",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "prepare": "husky install",
     "pre-commit": "pretty-quick --staged && npm run lint",
     "version": "git add -u . && git commit -m \"[RELEASE] - v$npm_package_version\"",
-    "postversion": "git push upstream DOP-3460"
+    "postversion": "git push upstream main"
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^5.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dop/redoc",
-  "version": "0.0.1-test-rc.2",
+  "version": "0.0.1-test-rc.3",
   "description": "ReDoc",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dop/redoc",
-  "version": "0.0.1-test-rc.1",
+  "version": "0.0.1-test-rc.2",
   "description": "ReDoc",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dop/redoc",
-  "version": "0.0.1-test-rc.0",
+  "version": "0.0.1-test-rc.1",
   "description": "ReDoc",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,9 @@
     "license-check": "license-checker --production --onlyAllow 'MIT;ISC;Apache-2.0;BSD;BSD-2-Clause;BSD-3-Clause;CC-BY-4.0;Python-2.0' --summary",
     "docker:build": "docker build -f config/docker/Dockerfile -t redoc .",
     "prepare": "husky install",
-    "pre-commit": "pretty-quick --staged && npm run lint"
+    "pre-commit": "pretty-quick --staged && npm run lint",
+    "version": "git add -u . && git commit -m \"[RELEASE] - v$npm_package_version\"",
+    "postversion": "git push upstream DOP-3460"
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^5.12.0",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "redoc",
-  "version": "2.0.0",
+  "name": "@dop/redoc",
+  "version": "0.0.1",
   "description": "ReDoc",
   "repository": {
     "type": "git",
-    "url": "git://github.com/Redocly/redoc"
+    "url": "https://github.com/mongodb-forks/redoc"
   },
   "browserslist": [
     "defaults"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dop/redoc",
-  "version": "0.0.1",
+  "version": "0.0.1-rc.0",
   "description": "ReDoc",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Stories/Links:

DOP-3460

### Notes:
Ideally, the workflow introduced here would involve building and then publishing to Artifactory or npm. Unfortunately, there are some issues with permissions that we may need to sort out first. In an effort to at least automate the manual effort it takes to create builds or releases for both Redoc and Redoc CLI, a new workflow has been introduced.

The workflow jobs follow the general pattern:

1) Detect if a commit with "[RELEASE] - etc." is committed to the branch.
2) Build and test.
3) Commit any build artifacts that may need to be added. 
   - This is specifically for the Redoc React component. The Redoc CLI pulls whatever version of the Redoc React component we need it to, but we're currently doing it off of GitHub. Unfortunately, without pushing the build/bundle files to the git branch or tag, the CLI fails to include all of the build files from the Redoc component needed. I attempted using certain npm scripts like `prepare`, but I've been having difficulty with that as well.
4) Create and push a tag.

Please see the updated README for more information.

### TODO before merging:

- [x] Remove references to DOP-3460 branch in workflow and npm scripts. This should be to the `main` branch.
- [x] Reset versions for both components to `0.0.0`.

### TODO after merging:

- [ ] Remove/delete test tags to avoid naming conflicts after version number resets, if needed.
- [ ] Create first release for `@dop/redoc` v1.0.0.
- [ ] Create PR to update version that `@dop/redoc-cli` of `@dop/redoc` to be `v1.0.0`.
- [ ] Create first release for `@dop/redoc-cli` v1.0.0.
- [ ] Test Autobuilder with new `@dop/redoc-cli` tag to ensure that future updates continue to work with new tags.