### PR TITLE
DOP-3460: Use PRs for releases

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -11,7 +11,8 @@ jobs:
       - name: Create PR
         uses: repo-sync/pull-request@v2
         with:
-          destination_branch: 'main'
+          # TODO-3460: Change back to "main" branch
+          destination_branch: 'DOP-3460-pr-workflow'
           pr_title: ${{ github.event.head_commit.message }}
           pr_body: |
             This is an automated PR.

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -22,7 +22,7 @@ jobs:
             - The version was updated as intended.
             - The PR title is in the format "[RELEASE] - "
             - The PR will be squashed and merged with the same PR title format.
-            - The PR has an empty description (i.e. remove "co-authored by" text, if exists).
+            - The PR commit description is empty prior to squash merging (i.e. remove "co-authored by" text, if exists).
 
             For more information, please see the [release](https://github.com/mongodb-forks/redoc/blob/main/.github/workflows/release.yml) workflow.
           pr_label: 'release'

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -22,8 +22,8 @@ jobs:
             - The correct component's version was updated.
             - The version was updated as intended.
             - The PR title is in the format "[RELEASE] - "
-            - The PR is squashed with the same commit message.
-            - The PR has an empty description.
+            - The PR will be squashed and merged with the same PR title format.
+            - The PR has an empty description (i.e. remove "co-authored by" text, if exists).
 
             For more information, please see the [release](https://github.com/mongodb-forks/redoc/blob/main/.github/workflows/release.yml) workflow.
           pr_label: 'release'

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,28 @@
+name: Create Release PR
+on:
+  push:
+    branches:
+      - 'releases/**'
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create PR
+        uses: repo-sync/pull-request@v2
+        with:
+          destination_branch: 'main'
+          pr_title: ${{ github.event.head_commit.message }}
+          pr_body: |
+            This is an automated PR.
+
+            Please double-check that:
+
+            - The correct component's version was updated.
+            - The version was updated as intended.
+            - The PR title is in the format "[RELEASE] - "
+            - The PR is squashed with the same commit message.
+            - The PR has an empty description.
+
+            For more information, please see the [release](https://github.com/mongodb-forks/redoc/blob/main/.github/workflows/release.yml) workflow.
+          pr_label: 'release'

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -11,8 +11,7 @@ jobs:
       - name: Create PR
         uses: repo-sync/pull-request@v2
         with:
-          # TODO-3460: Change back to "main" branch
-          destination_branch: 'DOP-3460-pr-workflow'
+          destination_branch: 'main'
           pr_title: ${{ github.event.head_commit.message }}
           pr_body: |
             This is an automated PR.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+      # TODO-3460: Remove after testing
+      - DOP-3460-pr-workflow
     paths:
       - 'package.json'
       - 'cli/package.json'
@@ -29,7 +31,6 @@ jobs:
         id: split
         with:
           msg: ${{ github.event.head_commit.message }}
-          separator: ' - '
       - name: Push build artifacts and create tag
         # Use build artifacts in current branch, but only push it to new tag.
         # Build artifacts are needed by redoc-cli since the dependency is pulled from a GitHub branch/tag.
@@ -38,11 +39,11 @@ jobs:
           git config user.name 'github-actions[bot]'
           git add -f bundles/ typings/
           git commit --no-verify -m 'Add build artifacts'
-          git tag ${{ steps.split.outputs._1 }}
+          git tag ${{ steps.split.outputs._2 }}
           git push --tags
   release-redoc-cli:
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.event.head_commit.message, '[RELEASE] - @dop/redoc-cli') }}
+    if: ${{ startsWith(github.event.head_commit.message, '[RELEASE] - @dop/redoc-cli@') }}
     env:
       NPM_BASE_64_AUTH: ${{ secrets.NPM_BASE_64_AUTH }}
       NPM_EMAIL: ${{ secrets.NPM_EMAIL }}
@@ -62,10 +63,9 @@ jobs:
         id: split
         with:
           msg: ${{ github.event.head_commit.message }}
-          separator: ' - '
       - name: Push build artifacts and create tag
         run: |
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git config user.name 'github-actions[bot]'
-          git tag ${{ steps.split.outputs._1 }}
+          git tag ${{ steps.split.outputs._2 }}
           git push --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - main
-      # TODO-3460: Remove after testing
-      - DOP-3460-pr-workflow
     paths:
       - 'package.json'
       - 'cli/package.json'

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Releasing the Redoc CLI can be done by:
 3) Run `npm install https://github.com/mongodb-forks/redoc.git#{VERSION_TAG}` to update the version of Redoc that the CLI uses.
    - Example: `npm install https://github.com/mongodb-forks/redoc.git#v1.0.0`. You should see the version set in the CLI's `package.json`.
 4) Run `npm version [major | minor | patch | prerelease --preid=rc]`.
-   - A commit should have been pushed to a new `releases/vX.Y.Z` branch.
+   - A commit should have been pushed to a new `releases/@dop/redoc-cli@X.Y.Z` branch.
    - The creation of the new branch should create a new pull request.
 5) Approve and merge the new pull request to the `main` branch.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ node <path/to/redoc/cli/index.js> build <path/to/spec/file/or/url> --options=<pa
 
 The Redoc React component and the Redoc CLI have 2 separate release processes. Because the Redoc CLI pulls its version of Redoc from GitHub, build artifacts are included in the version tag being installed.
 
-See the sections below for release steps for each component. A release commit will be pushed to the `main` branch of `mongodb-forks/redoc` after following the steps, which will trigger a GitHub workflow. The workflow is responsible for testing, building artifacts (for the Redoc component, if applicable), and creating a tag.
+See the sections below for release steps for each component. A pull request will be made with the necessary release changes. After merging the PR, a release commit will be pushed to the `main` branch of `mongodb-forks/redoc` after following the steps, which will trigger a GitHub workflow. The workflow is responsible for testing, building artifacts (for the Redoc component, if applicable), and creating a tag.
 
 :warning: Note: Ensure that your local clone of the `mongodb-forks/redoc` repo is clean and up-to-date with the `main` branch. Please check your remotes to ensure that the `upstream` remote is set to the `mongodb-forks/redoc` repo. Example:
 
@@ -60,6 +60,9 @@ Releasing the Redoc React component can be done by:
 
 1) Go to your local clone of the `mongodb-forks/redoc` repo and ensure you are on the latest iteration of the `main` branch.
 2) Run `npm version [major | minor | patch | prerelease --preid=rc]`.
+   - A commit should have been pushed to a new `releases/vX.Y.Z` branch.
+   - The creation of the new branch should create a new pull request.
+3) Approve and merge the new pull request to the `main` branch.
 
 #### Redoc CLI
 
@@ -70,6 +73,9 @@ Releasing the Redoc CLI can be done by:
 3) Run `npm install https://github.com/mongodb-forks/redoc.git#{VERSION_TAG}` to update the version of Redoc that the CLI uses.
    - Example: `npm install https://github.com/mongodb-forks/redoc.git#v1.0.0`. You should see the version set in the CLI's `package.json`.
 4) Run `npm version [major | minor | patch | prerelease --preid=rc]`.
+   - A commit should have been pushed to a new `releases/vX.Y.Z` branch.
+   - The creation of the new branch should create a new pull request.
+5) Approve and merge the new pull request to the `main` branch.
 
 ## About Redoc
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -10,8 +10,8 @@
     "node": ">=12.0.0"
   },
   "scripts": {
-    "version": "git add -u . && git commit -m \"[RELEASE] - @dop/redoc-cli@$npm_package_version\"",
-    "postversion": "git push upstream main"
+    "version": "git add -u . && git checkout -b releases/@dop/redoc-cli@$npm_package_version && git commit -m \"[RELEASE] - @dop/redoc-cli@$npm_package_version\"",
+    "postversion": "git push upstream releases/@dop/redoc-cli@$npm_package_version && git checkout - && git branch -D releases/@dop/redoc-cli@$npm_package_version"
   },
   "dependencies": {
     "chokidar": "^3.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dop/redoc",
-  "version": "0.0.1",
+  "version": "0.0.1-dop-3460.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dop/redoc",
-      "version": "0.0.1",
+      "version": "0.0.1-dop-3460.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/css": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     "docker:build": "docker build -f config/docker/Dockerfile -t redoc .",
     "prepare": "husky install",
     "pre-commit": "pretty-quick --staged && npm run lint",
-    "version": "git add -u . && git commit -m \"[RELEASE] - v$npm_package_version\"",
-    "postversion": "git push upstream main"
+    "version": "git add -u . && git checkout -b releases/v$npm_package_version && git commit -m \"[RELEASE] - v$npm_package_version\"",
+    "postversion": "git push upstream releases/v$npm_package_version && git checkout - && git branch -D releases/v$npm_package_version"
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^5.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dop/redoc",
-  "version": "0.0.0",
+  "version": "0.0.1-dop-3460.0",
   "description": "ReDoc",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Stories/Links:

DOP-3460
Follow-up to #7.

### Notes:

The previous PR assumes that we can just freely create commits from our local machines to the `main` branch. Despite having admin privileges, I was unable to get it working as expected. This PR introduces a new workflow to open pull requests for release branches intended to be merged into the `main` branch to avoid needing to turn off branch protection rules. Manual PRs would work well too but this workflow would hopefully result in less steps to remember (creating a PR, remembering what to title it, where to point it to, etc.)

See: #10 for example PR.