### PR TITLE
DOP-3525: Options json support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,20 @@ Make sure to run `npm run bundle` on the root folder of this repo before running
 With `node` installed, run by doing the following:
 
 ```
-node <path/to/redoc/cli/index.js> build <path/to/spec/file/or/url> --options=<path/to/options.json> --output=<path/to/custom/output/file/name.html>
+node <path/to/redoc/cli/index.js> build <path/to/spec/file/or/url> --options <path/to/options.json> --output=<path/to/custom/output/file/name.html>
 ```
 
-#### Versioned Options in the CLI
+#### Options Available to include
 
-If wanting to add versioning support in your build, you must create a JSON file with the following data structure (replace example values with any mock values):
+Custom DOP options are available to include within a local JSON file.
+
+Within your `options.json` in the root directory, specify the `siteTitle`, `backNavigationPath`, `versionData`, and/or `ignoreIncompatibleTypes` flag. 
+
+The `siteTitle` and `backNavigationPath` properties are used to personalize the `SideMenuBackButton` UI and navigation.
+
+The `ignoreIncompatibleTypes` flag will silence only "Incompatible Types" errors in the build process.
+
+The `versionData` property enables and populates the `VersionSelector` dropdown for versioned OpenAPI specs. The structure is as follows:
 
 ```
 {
@@ -55,18 +63,10 @@ If wanting to add versioning support in your build, you must create a JSON file 
 }
 ```
 
-After doing so, run the build much the same as above but with the following option added:
-Note: the path to the version data option JSON file should be referenced in relation to the `redoc/cli` directory
+After specifying all options, run the build:
 
 ```
---options.versionData=<path/to/mock/data/file.json/from/cli/directory>
-```
-
-Such as: 
-Note: this is referencing a JSON file in the root directory
-
-```
-node <path/to/redoc/cli/index.js> build <path/to/spec/file/or/url> --options.versionData=../version-data.json
+node <path/to/redoc/cli/index.js> build <path/to/spec/file/or/url> --options options.json
 ```
 
 ### Releasing

--- a/cli/__test__/build/configRedoc/index.test.ts
+++ b/cli/__test__/build/configRedoc/index.test.ts
@@ -27,29 +27,4 @@ describe('build', () => {
     expect(result).toContain('Found .redocly.yaml and using features.openapi options');
     expect(result).toContain('bundled successfully');
   });
-
-  it('should ingest version data from json file', () => {
-    const pathToTestData = '__test__/data/version-data.json';
-    const r = spawnSync(
-      'ts-node',
-      [
-        '../../../index.ts',
-        'build',
-        ' ../../../../demo/openapi.yaml',
-        '--output=redoc-test.html',
-        `--options.versionData=${pathToTestData}`,
-      ],
-      {
-        cwd: __dirname,
-        shell: true,
-      },
-    );
-
-    const out = r.stdout.toString('utf-8');
-    const err = r.stderr.toString('utf-8');
-    const result = `${out}\n${err}`;
-
-    expect(result).toContain(`Found ${pathToTestData} and using version data.`);
-    expect(result).toContain('bundled successfully');
-  });
 });

--- a/cli/__test__/data/version-data.json
+++ b/cli/__test__/data/version-data.json
@@ -1,8 +1,0 @@
-{
-  "active": {
-    "apiVersion": "2.0",
-    "resourceVersion": "2023-02-14"
-  },
-  "rootUrl": "https://mongodb.com/docs/atlas/reference/api-resources-spec/v2",
-  "resourceVersions": ["2022-09-09", "2022-10-18", "2028-02-14"]
-}

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -441,9 +441,6 @@ function getObjectOrJSON(options) {
     case 'object':
       return options;
     case 'string':
-      console.log(__dirname);
-      console.log(existsSync(options));
-      console.log(options);
       try {
         if (existsSync(options) && lstatSync(options).isFile()) {
           return JSON.parse(readFileSync(options, 'utf-8'));

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -439,24 +439,11 @@ function handleError(error: Error) {
 function getObjectOrJSON(options) {
   switch (typeof options) {
     case 'object':
-      if (options?.versionData) {
-        const { versionData: versionPath } = options;
-        const versionFilePath = resolve(__dirname, versionPath);
-        try {
-          if (existsSync(versionFilePath) && lstatSync(versionFilePath).isFile()) {
-            const versionData = JSON.parse(readFileSync(versionFilePath, 'utf-8'));
-            options.versionData = versionData;
-            console.log(`Found ${versionPath} and using version data.`);
-          }
-        } catch (e) {
-          console.log(
-            `Encountered error:\n\n${versionPath}\n\nis not a file with a valid JSON object.`,
-          );
-          handleError(e);
-        }
-      }
       return options;
     case 'string':
+      console.log(__dirname);
+      console.log(existsSync(options));
+      console.log(options);
       try {
         if (existsSync(options) && lstatSync(options).isFile()) {
           return JSON.parse(readFileSync(options, 'utf-8'));

--- a/options.json
+++ b/options.json
@@ -1,0 +1,13 @@
+{
+  "versionData": {
+    "active": {
+      "apiVersion": "2.0",
+      "resourceVersion": "2023-02-14"
+    },
+    "rootUrl": "https://mongodb.com/docs/atlas/reference/api-resources-spec/v2",
+    "resourceVersions": ["2022-09-09", "2022-10-18", "2023-02-14"]
+  },
+  "backNavigationPath": "https://www.mongodb.com/docs/atlas/",
+  "siteTitle": "MongoDB Atlas",
+  "ignoreIncompatibleTypes": true
+}

--- a/src/components/Redoc/Redoc.tsx
+++ b/src/components/Redoc/Redoc.tsx
@@ -70,9 +70,7 @@ export class Redoc extends React.Component<RedocProps> {
                   />
                 )) ||
                   null}
-                {options.versionData && typeof options.versionData == 'object' && (
-                  <VersionSelector {...options.versionData} />
-                )}
+                {options.versionData && <VersionSelector {...options.versionData} />}
                 <SideMenu menu={menu} />
               </StickyResponsiveSidebar>
               <ApiContentWrap className="api-content">

--- a/src/services/RedocNormalizedOptions.ts
+++ b/src/services/RedocNormalizedOptions.ts
@@ -61,7 +61,7 @@ export interface RedocRawOptions {
   backNavigationPath?: string;
   ignoreIncompatibleTypes?: boolean | string;
   siteTitle?: string;
-  versionData?: string;
+  versionData?: VersionData;
 }
 
 export interface VersionData {
@@ -279,7 +279,7 @@ export class RedocNormalizedOptions {
   backNavigationPath?: string;
   ignoreIncompatibleTypes: boolean;
   siteTitle?: string;
-  versionData?: string | VersionData;
+  versionData?: VersionData;
 
   constructor(raw: RedocRawOptions, defaults: RedocRawOptions = {}) {
     raw = { ...defaults, ...raw };

--- a/version-data.json
+++ b/version-data.json
@@ -1,8 +1,0 @@
-{
-  "active": {
-    "apiVersion": "2.0",
-    "resourceVersion": "2023-02-14"
-  },
-  "rootUrl": "https://mongodb.com/docs/atlas/reference/api-resources-spec/v2",
-  "resourceVersions": ["2022-09-09", "2022-10-18", "2023-02-14"]
-}


### PR DESCRIPTION
### Stories/Links:

DOP-3525

### Notes:

This PR enables all custom DOP options to be ingested from one local `options.json` file.