### PR TITLE
Set node version for GH Actions workflows

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,6 +10,9 @@ jobs:
       NPM_EMAIL: ${{ secrets.NPM_EMAIL }}
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
       - run: npm ci && npm ci --prefix cli
       - run: npm run bundle
       - run: npm run e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+        with:
+          node-version: 14
       - name: Install dependencies
         run: npm ci && npm ci --prefix cli
       - name: Create bundles
@@ -48,6 +50,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+        with:
+          node-version: 14
       - name: Install dependencies
         run: npm ci && npm ci --prefix cli
       - name: Create bundles

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,6 +10,9 @@ jobs:
       NPM_EMAIL: ${{ secrets.NPM_EMAIL }}
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
       - run: npm ci && npm ci --prefix cli
       - run: npm run bundle
       - run: npm test


### PR DESCRIPTION
### Context

There are some GH Actions having installation issues due to Artifactory auth ([example](https://github.com/mongodb-forks/redoc/actions/runs/4207581435/jobs/7302544757)). This may be happening because of the usage of npm v9 (see the npm version used in [that runner](https://github.com/actions/runner-images/blob/ubuntu22/20230217.1/images/linux/Ubuntu2204-Readme.md#package-management)). 

As a **temporary** workaround and to ensure compatibility with everything, the node version is being set to 14 (similar to what's set in the `.nvmrc` file). This currently falls in line with the node version set for both Snooty and the Autobuilder's respective workflows.

We should follow the instructions to change `.npmrc`'s `_auth` field to `//artifactory.corp.mongodb.com/artifactory/api/npm/npm/:_auth` after confirming that this has no impact on builds across our toolchain.