### PR TITLE
DOP-3523: VersionSelector select navigates to correct page

### DIFF
--- a/src/components/VersionSelector/Option.tsx
+++ b/src/components/VersionSelector/Option.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { KeyboardEvent } from 'react';
 import { StyledLi, StyledOptionText, StyledPlaceholder } from './styled.elements';
 import Checkmark from './CheckmarkSvg';
 import { OptionProps } from './types';
@@ -7,14 +8,14 @@ export const Option = ({ option, selected, onClick }: OptionProps) => {
   const KEY_ENTER = 'ENTER';
   const KEY_SPACE = 'SPACE';
 
-  const handleKeyPress = (event: React.KeyboardEvent) => {
+  const handleKeyPress = (event: KeyboardEvent) => {
     if (event.key === KEY_ENTER || event.key === KEY_SPACE) {
-      onClick();
+      onClick(option);
     }
   };
 
   return (
-    <StyledLi onClick={onClick} onKeyPress={handleKeyPress} selected={selected}>
+    <StyledLi onClick={() => onClick(option)} onKeyPress={handleKeyPress} selected={selected}>
       {selected ? <Checkmark /> : <StyledPlaceholder />}
       <StyledOptionText>{option}</StyledOptionText>
     </StyledLi>

--- a/src/components/VersionSelector/Option.tsx
+++ b/src/components/VersionSelector/Option.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { KeyboardEvent } from 'react';
 import { StyledLi, StyledOptionText, StyledPlaceholder } from './styled.elements';
 import Checkmark from './CheckmarkSvg';
 import { OptionProps } from './types';
@@ -8,7 +7,7 @@ export const Option = ({ option, selected, onClick }: OptionProps) => {
   const KEY_ENTER = 'ENTER';
   const KEY_SPACE = 'SPACE';
 
-  const handleKeyPress = (event: KeyboardEvent) => {
+  const handleKeyPress = (event: React.KeyboardEvent) => {
     if (event.key === KEY_ENTER || event.key === KEY_SPACE) {
       onClick(option);
     }

--- a/src/components/VersionSelector/VersionSelector.tsx
+++ b/src/components/VersionSelector/VersionSelector.tsx
@@ -21,19 +21,22 @@ import { useOutsideClick } from './use-outside-click';
 const VersionSelectorComponent = ({
   resourceVersions,
   active,
+  rootUrl,
   description,
 }: VersionSelectorProps): JSX.Element => {
-  const initialSelectedIdx = resourceVersions.indexOf(active.resourceVersion);
+  const selectedIdx = resourceVersions.indexOf(active.resourceVersion);
   const [open, setOpen] = React.useState<boolean>(false);
-  const [selectedIdx, setSelectedIdx] = React.useState<number>(initialSelectedIdx);
   const menuListRef = React.useRef(null);
   useOutsideClick(menuListRef, () => {
     if (open) setOpen(false);
   });
 
-  const handleClick = (idx: number) => {
-    setSelectedIdx(idx);
-    setOpen(false);
+  const handleClick = (idx: number, resourceVersion: string) => {
+    if (idx === selectedIdx) return setOpen(false);
+
+    // navigate to resource version spec
+    const selectedResourceVersionUrl = `${rootUrl}/${resourceVersion}`;
+    window.location.href = selectedResourceVersionUrl;
   };
 
   return (
@@ -57,7 +60,7 @@ const VersionSelectorComponent = ({
                 key={`option-${i}`}
                 selected={i === selectedIdx}
                 option={option}
-                onClick={() => handleClick(i)}
+                onClick={option => handleClick(i, option)}
               />
             ))}
           </StyledMenuList>

--- a/src/components/VersionSelector/types.ts
+++ b/src/components/VersionSelector/types.ts
@@ -12,7 +12,7 @@ export interface VersionSelectorProps {
 export interface OptionProps {
   option: string;
   selected: boolean;
-  onClick: () => void;
+  onClick: (option: string) => void;
 }
 
 export interface ArrowIconProps {

--- a/src/components/__tests__/VersionSelector.test.tsx
+++ b/src/components/__tests__/VersionSelector.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-internal-modules */
 import * as React from 'react';
-import { render } from 'enzyme';
+import { mount, render } from 'enzyme';
 import { VersionSelector } from '../VersionSelector';
 import * as versionData from './data/mockVersionData.json';
 
@@ -12,5 +12,22 @@ describe('VersionSelector', () => {
       `Version Selector: v${versionData.active.apiVersion}`,
     );
     expect(wrapper.find('button').text()).toBe(versionData.resourceVersions.slice(-1)[0]);
+  });
+
+  it('should have options', async () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      enumerable: true,
+      value: new URL(window.location.href),
+    });
+
+    const wrapper = mount(<VersionSelector {...versionData} />);
+    wrapper.find('button').simulate('click');
+    expect(wrapper.find('li')).toHaveLength(3);
+
+    wrapper.find('li').at(0).simulate('click');
+    expect(JSON.stringify(window.location)).toBe(
+      JSON.stringify(`${versionData.rootUrl}/${versionData.resourceVersions[0]}`),
+    );
   });
 });

--- a/src/components/__tests__/VersionSelector.test.tsx
+++ b/src/components/__tests__/VersionSelector.test.tsx
@@ -5,6 +5,20 @@ import { VersionSelector } from '../VersionSelector';
 import * as versionData from './data/mockVersionData.json';
 
 describe('VersionSelector', () => {
+  const { location } = window;
+
+  beforeEach((): void => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      enumerable: true,
+      value: new URL(window.location.href),
+    });
+  });
+
+  afterEach((): void => {
+    window.location.href = location.href;
+  });
+
   it('should correctly render VersionSelector', () => {
     const wrapper = render(<VersionSelector {...versionData} />);
     expect(wrapper).toMatchSnapshot();
@@ -14,13 +28,7 @@ describe('VersionSelector', () => {
     expect(wrapper.find('button').text()).toBe(versionData.resourceVersions.slice(-1)[0]);
   });
 
-  it('should have options', async () => {
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      enumerable: true,
-      value: new URL(window.location.href),
-    });
-
+  it('should navigate to spec after select change', async () => {
     const wrapper = mount(<VersionSelector {...versionData} />);
     wrapper.find('button').simulate('click');
     expect(wrapper.find('li')).toHaveLength(3);
@@ -29,5 +37,17 @@ describe('VersionSelector', () => {
     expect(JSON.stringify(window.location)).toBe(
       JSON.stringify(`${versionData.rootUrl}/${versionData.resourceVersions[0]}`),
     );
+  });
+
+  it('should not navigate after selecting active resource version', () => {
+    const wrapper = mount(<VersionSelector {...versionData} />);
+    wrapper.find('button').simulate('click');
+    expect(wrapper.find('li')).toHaveLength(3);
+
+    wrapper.find('li').at(2).simulate('click');
+    expect(JSON.stringify(window.location)).not.toBe(
+      JSON.stringify(`${versionData.rootUrl}/${versionData.resourceVersions[2]}`),
+    );
+    expect(JSON.stringify(window.location)).toBe(JSON.stringify(location.href));
   });
 });


### PR DESCRIPTION
### Stories/Links:

DOP-3523

### Notes:

Small PR to add full functionality to the VersionSelector component.

When a resource version Option is selected that is not the currently active resource version, the user is navigated to the associated API spec page for the desired resource version.