### PR TITLE
Version selector close

### DIFF
--- a/src/components/VersionSelector/VersionSelector.tsx
+++ b/src/components/VersionSelector/VersionSelector.tsx
@@ -24,7 +24,9 @@ const VersionSelectorComponent = ({
   rootUrl,
   description,
 }: VersionSelectorProps): JSX.Element => {
-  const selectedIdx = resourceVersions.indexOf(active.resourceVersion);
+  const [selectedIdx, setSelectedIdx] = React.useState(
+    resourceVersions.indexOf(active.resourceVersion),
+  );
   const [open, setOpen] = React.useState<boolean>(false);
   const menuListRef = React.useRef(null);
   useOutsideClick(menuListRef, () => {
@@ -37,6 +39,7 @@ const VersionSelectorComponent = ({
     // navigate to resource version spec
     const selectedResourceVersionUrl = `${rootUrl}/${resourceVersion}`;
     window.location.href = selectedResourceVersionUrl;
+    setSelectedIdx(idx);
     return setOpen(false);
   };
 

--- a/src/components/VersionSelector/VersionSelector.tsx
+++ b/src/components/VersionSelector/VersionSelector.tsx
@@ -37,6 +37,7 @@ const VersionSelectorComponent = ({
     // navigate to resource version spec
     const selectedResourceVersionUrl = `${rootUrl}/${resourceVersion}`;
     window.location.href = selectedResourceVersionUrl;
+    return setOpen(false);
   };
 
   return (


### PR DESCRIPTION
No ticket.

This PR serves to change selected option in the VersionSelector and close the dropdown itself, which will help users if there's any lag in navigating to the next page.