### PR TITLE
DOP-3612: modify labels for versioning

### DIFF
--- a/src/components/Redoc/Redoc.tsx
+++ b/src/components/Redoc/Redoc.tsx
@@ -60,7 +60,10 @@ export class Redoc extends React.Component<RedocProps> {
                   backNavigationPath={options.backNavigationPath}
                   siteTitle={options.siteTitle}
                 />
-                <SideMenuTitle>{store.spec.info.title}</SideMenuTitle>
+                <SideMenuTitle>
+                  {store.spec.info.title}
+                  {options.versionData && ` ${options.versionData.active.apiVersion}`}
+                </SideMenuTitle>
                 {(!options.disableSearch && (
                   <SearchBox
                     search={search!}

--- a/src/components/VersionSelector/VersionSelector.tsx
+++ b/src/components/VersionSelector/VersionSelector.tsx
@@ -46,7 +46,7 @@ const VersionSelectorComponent = ({
   return (
     <StyledWrapper ref={menuListRef}>
       <StyledSelectWrapper>
-        <StyledLabel>Version Selector: v{active.apiVersion}</StyledLabel>
+        <StyledLabel>Resource Version:</StyledLabel>
         {description && <StyledDescription>{description}</StyledDescription>}
         <StyledButton onClick={() => setOpen(!open)}>
           <StyledDisplay>

--- a/src/components/__tests__/VersionSelector.test.tsx
+++ b/src/components/__tests__/VersionSelector.test.tsx
@@ -22,9 +22,7 @@ describe('VersionSelector', () => {
   it('should correctly render VersionSelector', () => {
     const wrapper = render(<VersionSelector {...versionData} />);
     expect(wrapper).toMatchSnapshot();
-    expect(wrapper.find('label').text()).toBe(
-      `Version Selector: v${versionData.active.apiVersion}`,
-    );
+    expect(wrapper.find('label').text()).toBe(`Resource Version:`);
     expect(wrapper.find('button').text()).toBe(versionData.resourceVersions.slice(-1)[0]);
   });
 

--- a/src/components/__tests__/__snapshots__/VersionSelector.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/VersionSelector.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`VersionSelector should correctly render VersionSelector 1`] = `
     <label
       class="sc-eCApnc kkTJUz"
     >
-      Version Selector: v2.0
+      Resource Version:
     </label>
     <button
       aria-labelledby="View a different version of documentation."


### PR DESCRIPTION
### Stories/Links:

DOP-3612

### Screenshots (optional):

Before:


<img width="373" alt="Screen Shot 2023-02-03 at 1 52 29 PM" src="https://user-images.githubusercontent.com/22421112/229820376-44aea081-d602-4047-938f-dac131ad02a2.png">


-----
After:


<img width="371" alt="Screenshot 2023-04-04 at 10 07 25 AM" src="https://user-images.githubusercontent.com/22421112/229820429-a9bcf267-3739-457c-b473-b3bd0d8bc7ee.png">


### Notes:


Per the request from content, the VersionSelector label now correctly labels the dropdown as `Resource Version:`

Also, the header of the SideNav includes the API Version to provide clarity when versioned.