### PR TITLE
DOP-3613: Add built index file to CLI release

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+cli/index.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,5 +69,7 @@ jobs:
         run: |
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git config user.name 'github-actions[bot]'
+          git add -f cli/index.js
+          git commit --no-verify -m 'Add build artifacts'
           git tag ${{ steps.split.outputs._2 }}
           git push --tags


### PR DESCRIPTION
### Stories/Links:

DOP-3613

### Notes:

* Adds `cli/index.js` file to GH release workflow. I can cut new releases afterwards to double-check the action works as intended, but it should follow the same existing logic as the Redoc component's release.
* A separate PR will be created on the Autobuilder to take advantage of the new built index file directly after the new release is cut.