### PR TITLE
[DOP-3655]: Add GA script to redoc HTML

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -335,12 +335,9 @@ async function getPageHTML(
   let state;
   let redocStandaloneSrc;
   if (ssr) {
-    console.log('Prerendering docs');
-
     const specUrl = redocOptions.specUrl || (isURL(pathToSpec) ? pathToSpec : undefined);
     const store = await createStore(spec, specUrl, redocOptions);
     const sheet = new ServerStyleSheet();
-    console.log('server style sheet');
     // @ts-ignore
     html = renderToString(sheet.collectStyles(React.createElement(Redoc, { store })));
     console.log('render');
@@ -358,7 +355,6 @@ async function getPageHTML(
   return template({
     redocHTML: `
     <div id="redoc">${(ssr && html) || ''}</div>
-    <script>!function(e,n){var t=document.createElement("script"),o=null,x="pathway";t.async=!0,t.src='https://'+x+'.mongodb.com/'+(e?x+'-debug.js':''),document.head.append(t),t.addEventListener("load",function(){o=window.pathway.default,(n&&o.configure(n)),o.createProfile("mongodbcom").load(),window.segment=o})}();</script>
     <script>
     ${(ssr && `const __redoc_state = ${sanitizeJSONString(JSON.stringify(state))};`) || ''}
 

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -340,8 +340,6 @@ async function getPageHTML(
     const sheet = new ServerStyleSheet();
     // @ts-ignore
     html = renderToString(sheet.collectStyles(React.createElement(Redoc, { store })));
-    console.log('render');
-
     css = sheet.getStyleTags();
     state = await store.toJS();
 

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -340,8 +340,11 @@ async function getPageHTML(
     const specUrl = redocOptions.specUrl || (isURL(pathToSpec) ? pathToSpec : undefined);
     const store = await createStore(spec, specUrl, redocOptions);
     const sheet = new ServerStyleSheet();
+    console.log('server style sheet');
     // @ts-ignore
     html = renderToString(sheet.collectStyles(React.createElement(Redoc, { store })));
+    console.log('render');
+
     css = sheet.getStyleTags();
     state = await store.toJS();
 
@@ -355,6 +358,7 @@ async function getPageHTML(
   return template({
     redocHTML: `
     <div id="redoc">${(ssr && html) || ''}</div>
+    <script>!function(e,n){var t=document.createElement("script"),o=null,x="pathway";t.async=!0,t.src='https://'+x+'.mongodb.com/'+(e?x+'-debug.js':''),document.head.append(t),t.addEventListener("load",function(){o=window.pathway.default,(n&&o.configure(n)),o.createProfile("mongodbcom").load(),window.segment=o})}();</script>
     <script>
     ${(ssr && `const __redoc_state = ${sanitizeJSONString(JSON.stringify(state))};`) || ''}
 

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -335,6 +335,8 @@ async function getPageHTML(
   let state;
   let redocStandaloneSrc;
   if (ssr) {
+    console.log('Prerendering docs');
+
     const specUrl = redocOptions.specUrl || (isURL(pathToSpec) ? pathToSpec : undefined);
     const store = await createStore(spec, specUrl, redocOptions);
     const sheet = new ServerStyleSheet();

--- a/cli/template.hbs
+++ b/cli/template.hbs
@@ -1,24 +1,26 @@
-<!DOCTYPE html>
 <html>
 
-<head>
-  <meta charset="utf8" />
-  <title>{{title}}</title>
-  <!-- needed for adaptive design -->
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <style>
-    body {
-      padding: 0;
-      margin: 0;
-    }
-  </style>
-  {{{redocHead}}}
-  {{#unless disableGoogleFont}}<link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">{{/unless}}
-  <link href="https://www.mongodb.com/docs/assets/favicon.ico" rel="icon">
-</head>
+  <head>
+    <meta charset='utf8' />
+    <title>{{title}}</title>
+    <!-- needed for adaptive design -->
+    <meta name='viewport' content='width=device-width, initial-scale=1' />
+    <style>
+      body { padding: 0; margin: 0; }
+    </style>
+    {{{redocHead}}}
+    {{#unless disableGoogleFont}}<link
+        href='https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700'
+        rel='stylesheet'
+      />{{/unless}}
+    <link href='https://www.mongodb.com/docs/assets/favicon.ico' rel='icon' />
+    <script>!function(e,n){var
+      t=document.createElement("script"),o=null,x="pathway";t.async=!0,t.src='https://'+x+'.mongodb.com/'+(e?x+'-debug.js':''),document.head.append(t),t.addEventListener("load",function(){o=window.pathway.default,(n&&o.configure(n)),o.createProfile("mongodbcom").load(),window.segment=o})}();</script>
 
-<body>
-  {{{redocHTML}}}
-</body>
+  </head>
+
+  <body>
+    {{{redocHTML}}}
+  </body>
 
 </html>

--- a/cli/template.hbs
+++ b/cli/template.hbs
@@ -1,3 +1,4 @@
+<!DOCTYPE html>	
 <html>
 
   <head>


### PR DESCRIPTION
### Stories/Links:

[DOP-3655](https://jira.mongodb.org/browse/DOP-3655)


### Notes:
To verify, please run the Redoc CLI locally, and inspect the HTML in the Chrome dev tools. Verify that the script tag is properly loaded in the `head` element.
