### PR TITLE
added padding to bottom section

### DIFF
--- a/src/common-elements/panels.ts
+++ b/src/common-elements/panels.ts
@@ -35,6 +35,8 @@ export const Section = styled.div.attrs(props => ({
       `
     position: relative;
 
+    margin-bottom: 48px;
+
     &:not(:last-of-type):after {
       position: absolute;
       bottom: 0;


### PR DESCRIPTION
### Stories/Links:

DOP-3617

### Screenshots (optional):
![image](https://github.com/mongodb-forks/redoc/assets/135655735/6fc6e9d2-615f-4fe9-9c24-830d29af6403)
How the site looks post change

### Notes:
- Added padding to the bottom section between endpoints for more padding instead of adding padding to the header since we don't want all headers to have extra space at the top
- couldn't add the padding to the divider line since its a sudo element so added it to the section instead
