### PR TITLE
DOP-4200: Bump consistent nav to 2.0.3-rc.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@emotion/react": "^11.10.4",
         "@emotion/styled": "^11.10.4",
         "@leafygreen-ui/palette": "^3.4.4",
-        "@mdb/consistent-nav": "^1.2.39",
+        "@mdb/consistent-nav": "^2.0.3-rc.15",
         "@mdb/flora": "^1.5.6",
         "@mdx-js/react": "^1.6.22",
         "@redocly/openapi-core": "^1.0.0-beta.104",
@@ -2822,13 +2822,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@mdb/consistent-nav": {
-      "version": "1.2.39",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.2.39.tgz",
-      "integrity": "sha512-YTRRsNF3Vf42rw3ESYp5RUgFUZehO23M1ujHB1KKvndHS5pp9mXobZfz9rTroL0rKgJprT+9E6dQOqs6+yK5JA==",
+      "version": "2.0.3-rc.15",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.0.3-rc.15.tgz",
+      "integrity": "sha512-LJyBgPph/4oW63t6kDxOLAPjfD2CRHWGNusz2qqUs2huVqX1mp+WejYqTE9TALKVphnsD9stH7qI2jJ6d9GMMg==",
       "peerDependencies": {
         "@emotion/react": ">= 11.6.0",
         "@emotion/styled": ">= 11.6.0",
-        "@mdb/flora": ">= 0.20.5",
+        "@mdb/flora": "^1.7.1",
         "@mdx-js/react": "^1.6.22",
         "react": ">= 16.8",
         "react-dom": ">= 16.8",
@@ -2836,9 +2836,9 @@
       }
     },
     "node_modules/@mdb/flora": {
-      "version": "1.5.6",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/flora/-/@mdb/flora-1.5.6.tgz",
-      "integrity": "sha512-+ArnKzKYC/vZHsiD44vicGlcvn+mEkvMzQPW6gD1Gtr0YCiN/1U0hCXuvyRX7Add/MrQaO1IDjWLFsWjGhJ+HA==",
+      "version": "1.7.15",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/flora/-/@mdb/flora-1.7.15.tgz",
+      "integrity": "sha512-bBzpaO7lmpW+pgE5dqssHzdSCe+CJQR79TbnyM/eIpbUzPk8RhqFivCYhD7QTiKpXOYbcVfg7g9tjD+94Un7kg==",
       "dependencies": {
         "@imgix/js-core": "3.7.1",
         "codemirror": "5.62.2",
@@ -21859,15 +21859,15 @@
       "integrity": "sha512-ed71/pOusm9/I/7hTox38L5a/6UTk2nJr+b6ihQO/rh1oDblBvq48ID6wbJhmH/wif/SkSOAKPzXR9rKIu9uYg=="
     },
     "@mdb/consistent-nav": {
-      "version": "1.2.39",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.2.39.tgz",
-      "integrity": "sha512-YTRRsNF3Vf42rw3ESYp5RUgFUZehO23M1ujHB1KKvndHS5pp9mXobZfz9rTroL0rKgJprT+9E6dQOqs6+yK5JA==",
+      "version": "2.0.3-rc.15",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.0.3-rc.15.tgz",
+      "integrity": "sha512-LJyBgPph/4oW63t6kDxOLAPjfD2CRHWGNusz2qqUs2huVqX1mp+WejYqTE9TALKVphnsD9stH7qI2jJ6d9GMMg==",
       "requires": {}
     },
     "@mdb/flora": {
-      "version": "1.5.6",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/flora/-/@mdb/flora-1.5.6.tgz",
-      "integrity": "sha512-+ArnKzKYC/vZHsiD44vicGlcvn+mEkvMzQPW6gD1Gtr0YCiN/1U0hCXuvyRX7Add/MrQaO1IDjWLFsWjGhJ+HA==",
+      "version": "1.7.15",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/flora/-/@mdb/flora-1.7.15.tgz",
+      "integrity": "sha512-bBzpaO7lmpW+pgE5dqssHzdSCe+CJQR79TbnyM/eIpbUzPk8RhqFivCYhD7QTiKpXOYbcVfg7g9tjD+94Un7kg==",
       "requires": {
         "@imgix/js-core": "3.7.1",
         "codemirror": "5.62.2",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
     "@leafygreen-ui/palette": "^3.4.4",
-    "@mdb/consistent-nav": "^1.2.39",
+    "@mdb/consistent-nav": "^2.0.3-rc.15",
     "@mdb/flora": "^1.5.6",
     "@mdx-js/react": "^1.6.22",
     "@redocly/openapi-core": "^1.0.0-beta.104",

--- a/src/components/Redoc/styled.elements.tsx
+++ b/src/components/Redoc/styled.elements.tsx
@@ -4,6 +4,14 @@ export const StyledHeader = styled.header`
   position: relative;
   width: 100%;
   z-index: 99;
+
+  // Overwrite padding to match docs site's padding
+  nav > div > div {
+    ${media.greaterThan('medium')`
+      padding-left: 32px;
+      padding-right: 32px;
+    `};
+  }
 `;
 
 export const SideMenuTitle = styled.div`


### PR DESCRIPTION
### Stories/Links:

DOP-4200

### Screenshots (optional):

<img width="1512" alt="Screen Shot 2023-12-13 at 4 06 34 PM" src="https://github.com/mongodb-forks/redoc/assets/27821750/94b917e2-2996-4f18-9de9-c97ffb46d5af">

### Notes:

This PR bumps the consistent nav version to be the same as the Snooty frontend's. Seems like there's a weird thing where the padding on the docs site's consistent nav is 32px (see: [staging link](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/raymund.rodriguez/DOP-4200/index.html)) while by default on Redoc it's 48px... I tried looking into why there's such a such difference, but I couldn't find a root cause. In the interest of time, I overwrote the css to make it 32px to match the docs site's for now. If this becomes an issue, we can investigate further.