### PR TITLE
Upgrade and use Dark Mode nav

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@emotion/react": "^11.10.4",
         "@emotion/styled": "^11.10.4",
         "@leafygreen-ui/palette": "^3.4.4",
-        "@mdb/consistent-nav": "^2.0.3-rc.15",
+        "@mdb/consistent-nav": "^2.2.0",
         "@mdb/flora": "^1.5.6",
         "@mdx-js/react": "^1.6.22",
         "@redocly/openapi-core": "^1.0.0-beta.104",
@@ -2822,9 +2822,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@mdb/consistent-nav": {
-      "version": "2.0.3-rc.15",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.0.3-rc.15.tgz",
-      "integrity": "sha512-LJyBgPph/4oW63t6kDxOLAPjfD2CRHWGNusz2qqUs2huVqX1mp+WejYqTE9TALKVphnsD9stH7qI2jJ6d9GMMg==",
+      "version": "2.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.2.0.tgz",
+      "integrity": "sha512-JwA/NJF9GwdEGobvTkWQYfMktSMezhP5w89UIMmR7enGnERMbFDeBasJkfSsn6oNUuW/p57phoEHYfQ0G6bYAQ==",
       "peerDependencies": {
         "@emotion/react": ">= 11.6.0",
         "@emotion/styled": ">= 11.6.0",
@@ -21859,9 +21859,9 @@
       "integrity": "sha512-ed71/pOusm9/I/7hTox38L5a/6UTk2nJr+b6ihQO/rh1oDblBvq48ID6wbJhmH/wif/SkSOAKPzXR9rKIu9uYg=="
     },
     "@mdb/consistent-nav": {
-      "version": "2.0.3-rc.15",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.0.3-rc.15.tgz",
-      "integrity": "sha512-LJyBgPph/4oW63t6kDxOLAPjfD2CRHWGNusz2qqUs2huVqX1mp+WejYqTE9TALKVphnsD9stH7qI2jJ6d9GMMg==",
+      "version": "2.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.2.0.tgz",
+      "integrity": "sha512-JwA/NJF9GwdEGobvTkWQYfMktSMezhP5w89UIMmR7enGnERMbFDeBasJkfSsn6oNUuW/p57phoEHYfQ0G6bYAQ==",
       "requires": {}
     },
     "@mdb/flora": {

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
     "@leafygreen-ui/palette": "^3.4.4",
-    "@mdb/consistent-nav": "^2.0.3-rc.15",
+    "@mdb/consistent-nav": "^2.2.0",
     "@mdb/flora": "^1.5.6",
     "@mdx-js/react": "^1.6.22",
     "@redocly/openapi-core": "^1.0.0-beta.104",

--- a/src/components/Redoc/Redoc.tsx
+++ b/src/components/Redoc/Redoc.tsx
@@ -57,7 +57,22 @@ export class Redoc extends React.Component<RedocProps> {
           <OptionsProvider value={options}>
             <GlobalCss />
             <StyledHeader>
-              <UnifiedNav position="relative" property={{ name: 'DOCS', searchParams: [] }} />
+              <UnifiedNav
+                position="relative"
+                property={{ name: 'DOCS', searchParams: [] }}
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                darkMode={false}
+                className="nav-light"
+              />
+              <UnifiedNav
+                position="relative"
+                property={{ name: 'DOCS', searchParams: [] }}
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                darkMode={true}
+                className="nav-dark"
+              />
             </StyledHeader>
             <RedocWrap className="redoc-wrap">
               <StickyResponsiveSidebar menu={menu} className="menu-content">

--- a/src/globalStyles.ts
+++ b/src/globalStyles.ts
@@ -230,4 +230,20 @@ export const globalStyles = `
     --callbacks-title-outline: #3e647c;
     --callbacks-details-bg: ${palette.gray.dark3};
   }
+
+  .nav-dark {
+    display: none;
+  }
+
+  .nav-light {
+    display: initial;
+  }
+
+  .dark-theme .nav-dark {
+    display: initial;
+  }
+
+  .dark-theme .nav-light {
+    display: none;
+  }
 `;


### PR DESCRIPTION
### Stories/Links:

DOP-4832

### Screenshots (optional):

<img width="1666" alt="Screenshot 2024-09-05 at 4 48 44 PM" src="https://github.com/user-attachments/assets/7b9e89b3-4603-4132-aa69-6307913540b6">


### Notes:

The ts-ignore statements are terrible. But I do not know why it will not compile. Even after upgrading the consistent-nav, it does not say that darkMode is an allowed prop. There must be something wrong in the declaration within the consistent-nav. There definitely is, because the package has `darkMode` in its source code yet it doesn't have it in its type declarations. The prop completely works, as you can see in the screenshot.

### To build

To build locally and review, here are helpful steps:

----

Ensure [Artifactory](https://artifactory.corp.mongodb.com/ui/packages) credentials are set up and set to `NPM_BASE_64_AUTH` and `NPM_EMAIL` env variables. This should be similar to the setup on [Snooty](https://github.com/mongodb/snooty/#installation). Below are the instructions to work with Redoc locally with custom MongoDB components, such as the Consistent Nav:

1) In `redoc`/root folder of this fork, run `npm install`.
2) In `redoc/cli` folder, run `npm install`.
3) In `redoc/cli` folder, run: `npm link ../ ../node_modules/react/ ../node_modules/styled-components/`. This will link certain CLI dependencies to be compatible with the local instance and fork of Redoc.
4) In `redoc`/root folder, run: `npm run bundle`. This will create bundled files needed by the CLI / needed to run the CLI.
5) Run the following command to see a full example built into a local file called `redoc-static.html` in your root directory.

``` 
node cli/index.js build https://mongodb-mms-prod-build-server.s3.amazonaws.com/openapi/7f44860f3d20f152e7f187fe498a104aa7a9e3ba.json  --options options.json
```

6) Once built, use your browser to view the static html by putting the path to that file in your browser as a url

----

